### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,1 @@
-# CODEOWNERS: https://help.github.com/articles/about-codeowners/
-
-# Primary repo maintainers
-*       @ethanfrey
-*       @alpe
+** @cosmos/stack-team


### PR DESCRIPTION
Adds `.github/CODEOWNERS` to assign `@cosmos/stack-team` as code owners for all files.